### PR TITLE
Fix url template tags for Django 1.5

### DIFF
--- a/mce_filebrowser/templates/filebrowser.html
+++ b/mce_filebrowser/templates/filebrowser.html
@@ -1,4 +1,5 @@
 {% load staticfiles i18n thumbnail %}
+{% load url from future %}
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>


### PR DESCRIPTION
In Django 1.5 url tags will spit out NoReverseMatch errors such as:

NoReverseMatch at /mce_filebrowser/image/
Reverse for ''mce-filebrowser-remove-image'' with arguments '(1L,)' and keyword arguments '{}' not found.

This patch add {% load url from future %} in the templates.

Tested on Django 1.4.5 and 1.5.1
