### PR TITLE
add django 1.6 compatibility

### DIFF
--- a/mce_filebrowser/urls.py
+++ b/mce_filebrowser/urls.py
@@ -1,4 +1,7 @@
-from django.conf.urls.defaults import *
+try:
+    from django.conf.urls.defaults import patterns, url
+except ImportError:
+    from django.conf.urls import patterns, url
 
 from mce_filebrowser import views
 


### PR DESCRIPTION
In Django==1.6 django.conf.urls.defaults removed. The functions include(), patterns() and url() plus handler404, handler500, are now available through django.conf.urls . So i added workaround to save compatibility with old and new django versions.
